### PR TITLE
docs: clarify dual-key pattern for database IDs

### DIFF
--- a/stubs/CLAUDE.md
+++ b/stubs/CLAUDE.md
@@ -66,7 +66,8 @@ The Base model provides:
 
 ### Database Conventions
 
-- **Primary keys**: Always UUID (`$table->uuid('id')->primary()`)
+- **Primary keys**: Dual-key pattern — auto-increment `id` (internal primary key) + `uuid` column (public identifier, indexed)
+- **External references**: Always use UUID, never expose integer `id`
 - **Soft deletes**: Use for all user-facing models
 - **Column naming**: snake_case
 


### PR DESCRIPTION
The documentation stated UUID was the primary key, but the actual implementation uses a dual-key pattern:

- $table->id() as internal primary key
- $table->uuid('uuid')->index() for external references

Updated stubs/CLAUDE.md to reflect the actual implementation.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
any dependencies that are required for this change.

Fixes #9 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- OS:
- Browser:
- PHP Version:
- Laravel Version:

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have ran `composer format` to fix the code styling
- [ ] Create one time operation for seeder that need to be run (if available)
- [ ] Include seeder command if needed into the deployment checklist

## Screenshots (if appropriate):
