### PR TITLE
Right-align the new-tab icon in sidebar menu items

### DIFF
--- a/stubs/resources/views/components/menu/collapsed.blade.php
+++ b/stubs/resources/views/components/menu/collapsed.blade.php
@@ -24,7 +24,7 @@
                         @if (data_get($child, 'target') === '_blank')
                             <flux:menu.item icon="{{ data_get($child, 'icon', 'circle') }}"
                                 :href="data_get($child, 'url')" target="_blank" rel="noopener noreferrer">
-                                <span class="inline-flex items-center gap-1.5">
+                                <span class="flex w-full items-center justify-between gap-2">
                                     <span>{{ data_get($child, 'label') }}</span>
                                     <flux:icon.arrow-top-right-on-square class="size-3.5 shrink-0 opacity-60" />
                                 </span>
@@ -56,7 +56,7 @@
                     @if (data_get($menuItem, 'target') === '_blank')
                         <flux:menu.item icon="{{ data_get($menuItem, 'icon', 'circle') }}"
                             :href="data_get($menuItem, 'url')" target="_blank" rel="noopener noreferrer">
-                            <span class="inline-flex items-center gap-1.5">
+                            <span class="flex w-full items-center justify-between gap-2">
                                 <span>{{ data_get($menuItem, 'label', 'Menu Item') }}</span>
                                 <flux:icon.arrow-top-right-on-square class="size-3.5 shrink-0 opacity-60" />
                             </span>
@@ -86,7 +86,7 @@
                         @if (data_get($child, 'target') === '_blank')
                             <flux:menu.item icon="{{ data_get($child, 'icon', 'circle') }}"
                                 :href="data_get($child, 'url')" target="_blank" rel="noopener noreferrer">
-                                <span class="inline-flex items-center gap-1.5">
+                                <span class="flex w-full items-center justify-between gap-2">
                                     <span>{{ data_get($child, 'label') }}</span>
                                     <flux:icon.arrow-top-right-on-square class="size-3.5 shrink-0 opacity-60" />
                                 </span>

--- a/stubs/resources/views/components/menu/expanded.blade.php
+++ b/stubs/resources/views/components/menu/expanded.blade.php
@@ -30,7 +30,7 @@
                 <flux:navlist.item icon="{{ data_get($menuItem, 'icon', 'circle') }}"
                     :href="data_get($menuItem, 'url')" :current="data_get($menuItem, 'active', false)"
                     target="_blank" rel="noopener noreferrer">
-                    <span class="inline-flex items-center gap-1.5">
+                    <span class="flex w-full items-center justify-between gap-2">
                         <span>{{ data_get($menuItem, 'label', 'Menu Item') }}</span>
                         <flux:icon.arrow-top-right-on-square class="size-3.5 shrink-0 opacity-60" />
                     </span>

--- a/stubs/resources/views/components/navlist-with-child.blade.php
+++ b/stubs/resources/views/components/navlist-with-child.blade.php
@@ -24,7 +24,7 @@
                         <flux:navlist.item icon="{{ data_get($child, 'icon') }}" :href="data_get($child, 'url')"
                             :current="data_get($child, 'active')" class="text-sm"
                             target="_blank" rel="noopener noreferrer">
-                            <span class="inline-flex items-center gap-1.5">
+                            <span class="flex w-full items-center justify-between gap-2">
                                 <span>{{ data_get($child, 'label') }}</span>
                                 <flux:icon.arrow-top-right-on-square class="size-3.5 shrink-0 opacity-60" />
                             </span>


### PR DESCRIPTION
Follow-up to #42. Push the open-in-new-tab `arrow-top-right-on-square` icon to the far right of the menu row (`flex w-full justify-between`) so it aligns with the expandable-group chevrons / other trailing icons, instead of hugging the label. Applied in expanded, collapsed (group flyout + children), and navlist-with-child.

🤖 Generated with [Claude Code](https://claude.com/claude-code)