### PR TITLE
Enable Telescope by default (exception watcher only)

### DIFF
--- a/src/StartCommand.php
+++ b/src/StartCommand.php
@@ -146,7 +146,7 @@ class StartCommand extends Command
         $output->writeln('<info>7. Optional</info>:');
         $output->writeln('   • <comment>php artisan boost:install</comment>   — finish interactive Laravel Boost setup');
         $output->writeln('   • <comment>php artisan horizon</comment>         — run the queue worker dashboard');
-        $output->writeln('   • <comment>php artisan telescope:install</comment> — set <comment>TELESCOPE_ENABLED=true</comment> first');
+        $output->writeln('   • <comment>php artisan telescope</comment>     — Telescope is enabled (exception watcher only); dashboard at /telescope in local/staging');
         $output->writeln('');
         $output->writeln('<comment>📚 Full guide:</comment> <info>docs/01-getting-started/</info> in the new project');
         $output->writeln('<comment>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</comment>');

--- a/stubs/.env.example
+++ b/stubs/.env.example
@@ -61,7 +61,9 @@ VITE_APP_NAME="${APP_NAME}"
 
 TELESCOPE_PATH=telescope
 TELESCOPE_DRIVER=database
-TELESCOPE_ENABLED=false
+# Enabled by default, but only the exception watcher records (all other watchers
+# below are off). Dashboard access is still gated to local/staging via access.telescope.
+TELESCOPE_ENABLED=true
 TELESCOPE_BATCH_WATCHER=false
 TELESCOPE_CACHE_WATCHER=false
 TELESCOPE_CLIENT_REQUEST_WATCHER=false

--- a/stubs/CLAUDE.md
+++ b/stubs/CLAUDE.md
@@ -665,7 +665,7 @@ SUPERADMIN_PASSWORD=CHANGE_ME_BEFORE_DEPLOY
 
 # Features
 ACCESS_CONTROL_ENABLED=true
-TELESCOPE_ENABLED=false
+TELESCOPE_ENABLED=true   # exception watcher only; dashboard gated to local/staging
 
 # Security
 SESSION_ENCRYPT=true

--- a/stubs/docs/05-security/soc2-compliance.md
+++ b/stubs/docs/05-security/soc2-compliance.md
@@ -82,7 +82,7 @@ This document describes the security controls implemented in this project to sup
 ### Secrets Management
 - No default credentials in `.env.example` — all sensitive values use `CHANGE_ME_BEFORE_DEPLOY` placeholders
 - Telescope hides sensitive request parameters (`password`, `password_confirmation`, `current_password`, `secret`) and headers (`authorization`, `cookie`, CSRF tokens)
-- Telescope disabled by default (`TELESCOPE_ENABLED=false`)
+- Telescope enabled by default with only the exception watcher (`TELESCOPE_ENABLED=true`); dashboard access is gated to local/staging via the `access.telescope` ability
 
 ### Access Control
 - Media files stored with `private` visibility
@@ -123,7 +123,7 @@ This document describes the security controls implemented in this project to sup
 | `AUDIT_CONSOLE` | `true` | Audit console commands |
 | `BACKUP_RETENTION_DAYS` | `30` | Days to retain backups |
 | `BACKUP_GPG_RECIPIENT` | (empty) | GPG key ID for backup encryption |
-| `TELESCOPE_ENABLED` | `false` | Enable/disable Telescope |
+| `TELESCOPE_ENABLED` | `true` | Enable/disable Telescope (exception watcher only; dashboard gated to local/staging) |
 
 ### Key Files
 


### PR DESCRIPTION
Ship `TELESCOPE_ENABLED=true` in the stub `.env.example`. Only the **exception watcher** records — all other Telescope watchers remain off (already the case in `.env.example`), keeping overhead minimal while capturing exceptions out of the box.

Dashboard access is unchanged: still gated to local/staging via the `access.telescope` ability (which also checks `config('telescope.enabled')`), so the Telescope sidebar item now shows in those environments and opens in a new tab.

Also updated the post-setup hint (`StartCommand`), the stub `CLAUDE.md` env reference, and the SOC2 doc.

Verified in the sandbox: `config('telescope.enabled')` true, `telescope_entries` table present, `telescope/{view?}` route registered (name `telescope`), and the `access.telescope` gate allows the superadmin in local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)