### PR TITLE
feat(sidebar): section switcher + registry-driven menu & breadcrumbs

### DIFF
--- a/stubs/app/Actions/Builder/Breadcrumb.php
+++ b/stubs/app/Actions/Builder/Breadcrumb.php
@@ -33,13 +33,6 @@ use Illuminate\Support\Facades\Route;
  */
 class Breadcrumb
 {
-    /**
-     * Menu builders searched (in order) when resolving the active URL.
-     *
-     * @var array<int, string>
-     */
-    private const SOURCES = ['administration', 'media-management', 'sidebar-footer', 'sidebar'];
-
     /** @var array<int, array{label: string, url: ?string}> */
     private array $items = [];
 
@@ -120,11 +113,28 @@ class Breadcrumb
     }
 
     /**
+     * Menu builders searched (in order) when resolving the active URL. Derived
+     * from config/menu.php so the breadcrumb sources and the sidebar (sections +
+     * footer + globals) can never drift. Sections are searched first so a
+     * section leaf wins over a same-URL global.
+     *
+     * @return array<int, string>
+     */
+    private static function sources(): array
+    {
+        return array_values(array_unique(array_merge(
+            (array) config('menu.sections', ['administration', 'media-management']),
+            (array) config('menu.footer', ['sidebar-footer']),
+            (array) config('menu.globals', ['sidebar']),
+        )));
+    }
+
+    /**
      * Resolve the trail by matching $url against each menu builder's tree.
      */
     private function resolveByUrl(string $url): bool
     {
-        foreach (self::SOURCES as $source) {
+        foreach (self::sources() as $source) {
             $menu = menu($source);
 
             $path = $this->search($menu->menus()->all(), $url);

--- a/stubs/app/Actions/Builder/Menu/SectionResolver.php
+++ b/stubs/app/Actions/Builder/Menu/SectionResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Actions\Builder\Menu;
 
+use Illuminate\Support\Collection;
+
 /**
  * Resolves the sidebar "sections" for the section switcher.
  *
@@ -23,8 +25,8 @@ class SectionResolver
 {
     /**
      * @return array{
-     *     sections: array<int, array{key: string, label: string, icon: string, items: \Illuminate\Support\Collection, landing: string, matchLen: int, owns: bool}>,
-     *     active: array{key: string, label: string, icon: string, items: \Illuminate\Support\Collection, landing: string, matchLen: int, owns: bool}|null
+     *     sections: array<int, array{key: string, label: string, icon: string, items: Collection, landing: string, matchLen: int, owns: bool}>,
+     *     active: array{key: string, label: string, icon: string, items: Collection, landing: string, matchLen: int, owns: bool}|null
      * }
      */
     public static function resolve(): array

--- a/stubs/app/Actions/Builder/Menu/SectionResolver.php
+++ b/stubs/app/Actions/Builder/Menu/SectionResolver.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Builder\Menu;
+
+/**
+ * Resolves the sidebar "sections" for the section switcher.
+ *
+ * Reads the ordered section builder keys from config('menu.sections'), builds
+ * each one, drops any the current user can't see (unauthorized or empty), and
+ * returns the visible sections plus the one that owns the current page.
+ *
+ * Each section's label/icon/landing come from the builder's heading
+ * (getHeadingLabel/Icon/Url), so there is no duplicated metadata — the builder
+ * is the single source of truth. Landing falls back to the first real leaf URL.
+ *
+ * "Active" is chosen by LONGEST URL-prefix match, so a sub-page such as
+ * /admin/roles/42/edit keeps its parent section selected even though no menu
+ * item matches that exact URL.
+ */
+class SectionResolver
+{
+    /**
+     * @return array{
+     *     sections: array<int, array{key: string, label: string, icon: string, items: \Illuminate\Support\Collection, landing: string, matchLen: int, owns: bool}>,
+     *     active: array{key: string, label: string, icon: string, items: \Illuminate\Support\Collection, landing: string, matchLen: int, owns: bool}|null
+     * }
+     */
+    public static function resolve(): array
+    {
+        $currentUrl = request()->url();
+        $sections = [];
+
+        foreach ((array) config('menu.sections', []) as $key) {
+            $menu = menu($key);
+
+            if (! $menu->isAuthorized()) {
+                continue;
+            }
+
+            $items = $menu->menus();
+
+            if ($items->isEmpty()) {
+                continue;
+            }
+
+            $matchLen = 0;
+
+            foreach (self::leafUrls($items->all()) as $url) {
+                if ($currentUrl === $url || str_starts_with($currentUrl, rtrim($url, '/').'/')) {
+                    $matchLen = max($matchLen, strlen($url));
+                }
+            }
+
+            $sections[] = [
+                'key' => $key,
+                'label' => $menu->getHeadingLabel() ?? $key,
+                'icon' => $menu->getHeadingIcon() ?? 'circle',
+                'items' => $items,
+                'landing' => $menu->getHeadingUrl() ?? self::firstLeafUrl($items->all()) ?? '#',
+                'matchLen' => $matchLen,
+                'owns' => $matchLen > 0,
+            ];
+        }
+
+        $active = collect($sections)->where('matchLen', '>', 0)->sortByDesc('matchLen')->first()
+            ?? ($sections[0] ?? null);
+
+        return ['sections' => $sections, 'active' => $active];
+    }
+
+    /**
+     * First real (non-'#') leaf URL, recursing into sub-groups. Used as the
+     * section landing when the builder sets no explicit heading URL.
+     *
+     * @param  array<int, array<string, mixed>>  $items
+     */
+    private static function firstLeafUrl(array $items): ?string
+    {
+        foreach ($items as $item) {
+            $children = $item['children'] ?? [];
+
+            if (! empty($children)) {
+                if (($url = self::firstLeafUrl($children)) !== null) {
+                    return $url;
+                }
+
+                continue;
+            }
+
+            $url = $item['url'] ?? null;
+
+            if (! empty($url) && $url !== '#') {
+                return $url;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Every real (non-'#') leaf URL under a section, for prefix-based active
+     * detection.
+     *
+     * @param  array<int, array<string, mixed>>  $items
+     * @return array<int, string>
+     */
+    private static function leafUrls(array $items): array
+    {
+        $urls = [];
+
+        foreach ($items as $item) {
+            $children = $item['children'] ?? [];
+
+            if (! empty($children)) {
+                $urls = array_merge($urls, self::leafUrls($children));
+            }
+
+            $url = $item['url'] ?? null;
+
+            if (! empty($url) && $url !== '#') {
+                $urls[] = $url;
+            }
+        }
+
+        return $urls;
+    }
+}

--- a/stubs/config/menu.php
+++ b/stubs/config/menu.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+|--------------------------------------------------------------------------
+| Sidebar menu structure
+|--------------------------------------------------------------------------
+|
+| Single source of truth for how the sidebar is composed. Each value is a
+| menu-builder key resolved by App\Actions\Builder\Menu (see support/menu.php).
+|
+| - globals:  builders pinned at the top, always visible (no section heading),
+|             e.g. Dashboard and Notifications.
+| - sections: builders offered in the section switcher. The sidebar shows ONE
+|             section at a time; picking one from the dropdown navigates to its
+|             landing page. A section derives its label, icon and landing URL
+|             from the builder's heading (setHeadingLabel / setHeadingIcon /
+|             setHeadingUrl), falling back to the builder's first item URL.
+| - footer:   builders pinned to the bottom, below the spacer (e.g. Resources).
+|
+| The breadcrumb builder (App\Actions\Builder\Breadcrumb) reads this SAME list,
+| so the sidebar and breadcrumbs can never drift. Add a section by creating its
+| menu builder in app/Actions/Builder/Menu/ and appending its key to `sections`.
+|
+*/
+
+return [
+    'globals' => [
+        'sidebar',
+    ],
+
+    'sections' => [
+        'administration',
+        'media-management',
+    ],
+
+    'footer' => [
+        'sidebar-footer',
+    ],
+];

--- a/stubs/docs/02-development/09-sidebar.md
+++ b/stubs/docs/02-development/09-sidebar.md
@@ -28,57 +28,95 @@ This layout is wrapped by `resources/views/components/layouts/app.blade.php` whi
 
 The sidebar layout includes:
 - Flux sidebar component with sticky/stashable configuration
-- Navigation using `<x-menu>` components for each menu builder
+- Global items (`<x-menu>`), the section switcher (`<x-section-switcher>`), and footer items
 - Desktop and mobile user menu dropdowns
 - Toast notification system
 - Session message to toast conversion
 - `@auth` / `@else` guard for unauthenticated users
 
-### Menu Builders in the Sidebar
+### Sidebar composition — `config/menu.php`
 
-The sidebar renders these menu builders in order:
+`config/menu.php` is the **single source of truth** for how the sidebar is
+composed. Every value is a menu-builder key (resolved by `app/Actions/Builder/Menu.php`):
+
+```php
+return [
+    'globals'  => ['sidebar'],                             // pinned on top (no heading)
+    'sections' => ['administration', 'media-management'],  // shown one-at-a-time via the switcher
+    'footer'   => ['sidebar-footer'],                      // pinned to the bottom
+];
+```
+
+The layout renders globals, then the section switcher, then the footer:
 
 ```blade
 <flux:navlist variant="outline">
-    <x-menu menu-builder="sidebar" />
-    <x-menu menu-builder="user-management" />
-    <x-menu menu-builder="media-management" />
-    <x-menu menu-builder="settings" />
-    <x-menu menu-builder="audit-monitoring" />
+    @foreach (config('menu.globals') as $builder)
+        <x-menu :menu-builder="$builder" />
+    @endforeach
+</flux:navlist>
+
+<x-section-switcher />
+
+<flux:spacer />
+
+<flux:navlist variant="outline">
+    @foreach (config('menu.footer') as $builder)
+        <x-menu :menu-builder="$builder" />
+    @endforeach
 </flux:navlist>
 ```
 
-### Menu Builder Classes
+The breadcrumb builder (`app/Actions/Builder/Breadcrumb.php`) reads this **same**
+list, so navigation and breadcrumbs can never drift.
+
+### Section switcher
+
+`sections` are **not** stacked as groups. A single dropdown
+(`resources/views/components/section-switcher.blade.php`) names the active
+section; the sidebar shows only that section's items. Picking a section
+navigates (`wire:navigate`) to its landing page.
+
+`App\Actions\Builder\Menu\SectionResolver` builds the sections. For each key in
+`config('menu.sections')` it:
+
+- drops the section if the user can't see it (unauthorized or empty);
+- takes its **label / icon / landing** from the builder heading
+  (`getHeadingLabel` / `getHeadingIcon` / `getHeadingUrl`) — no duplicated
+  metadata — falling back to the first item's URL for the landing;
+- marks the **active** section by longest URL-prefix match, so a sub-page like
+  `/admin/roles/42/edit` keeps Administration selected even though no menu item
+  matches that exact URL.
+
+In the collapsed rail each section becomes a flyout icon (shared
+`components/menu/collapsed.blade.php`). When no section is authorized the
+switcher renders nothing.
+
+### Menu builder classes
 
 Located in `app/Actions/Builder/Menu/`:
 
-| Class | Builder Key | Heading | Items |
-|-------|-------------|---------|-------|
-| `Base.php` | — | — | Abstract base class |
-| `Sidebar.php` | `sidebar` | *(none)* | Dashboard, Notifications |
-| `UserManagement.php` | `user-management` | User Management | Users, Roles |
-| `MediaManagement.php` | `media-management` | Media | Media Library |
-| `Settings.php` | `settings` | Settings | General |
-| `AuditMonitoring.php` | `audit-monitoring` | Audit & Monitoring | Audit Trail, Telescope, Horizon |
+| Class | Builder key | Role | Heading |
+|-------|-------------|------|---------|
+| `Base.php` | — | Abstract base class | — |
+| `Sidebar.php` | `sidebar` | Global (pinned top) | *(none)* — Dashboard, Notifications |
+| `Administration.php` | `administration` | Section | Administration → `admin.index` |
+| `MediaManagement.php` | `media-management` | Section | Media |
+| `SidebarFooter.php` | `sidebar-footer` | Footer (pinned bottom) | Resources |
+| `SectionResolver.php` | — | Resolves sections for the switcher | — |
 
-### Menu Router
+### Menu router
 
 `app/Actions/Builder/Menu.php` routes builder keys to classes:
 
 ```php
-public function build(string $builder): Builder|ContractsMenu
-{
-    $class = match ($builder) {
-        'sidebar' => Sidebar::class,
-        'user-management' => UserManagement::class,
-        'media-management' => MediaManagement::class,
-        'settings' => Settings::class,
-        'audit-monitoring' => AuditMonitoring::class,
-        default => Sidebar::class,
-    };
-
-    return (new $class)->build();
-}
+$class = match ($builder) {
+    'sidebar' => Sidebar::class,
+    'administration' => Administration::class,
+    'media-management' => MediaManagement::class,
+    'sidebar-footer' => SidebarFooter::class,
+    default => Sidebar::class,
+};
 ```
 
 ## Base Menu Builder
@@ -257,11 +295,15 @@ class Reports extends Base
 'reports' => Reports::class,
 ```
 
-3. Add to the sidebar layout:
+3. Add the key to `config/menu.php` — as a `sections` entry (offered in the
+   switcher) or a `globals`/`footer` entry (pinned). Set `setHeadingUrl()` on the
+   builder so the switcher and breadcrumb use the right landing page:
 
-```blade
-<x-menu menu-builder="reports" />
+```php
+'sections' => ['administration', 'media-management', 'reports'],
 ```
+
+That's the only wiring step — the sidebar and breadcrumbs both read `config/menu.php`.
 
 ## Menu Component
 
@@ -335,4 +377,15 @@ in collapsed mode. Without it, the rail falls back to a generic `circle` icon.
 
 ### Adding Menu to Sidebar
 
-Always add `<x-menu menu-builder="your-key" />` inside the `<flux:navlist>` block in `resources/views/components/layouts/app/sidebar.blade.php`.
+Register the builder in `app/Actions/Builder/Menu.php`, then add its key to
+`config/menu.php` (`sections`, `globals`, or `footer`). Do **not** hand-edit the
+sidebar layout — it renders whatever `config/menu.php` lists.
+
+### Section Not Selectable / Wrong Section Highlighted
+
+1. Confirm the key is in `config('menu.sections')` and the builder is authorized.
+2. The switcher's landing comes from the builder's `setHeadingUrl()`, falling
+   back to its first item — a section whose items are all sub-groups (url `#`)
+   needs a heading URL or a first real leaf, or it will land on `#`.
+3. Active detection is longest URL-prefix — ensure the section's item URLs share
+   a distinct path segment from other sections.

--- a/stubs/resources/views/components/layouts/app/sidebar.blade.php
+++ b/stubs/resources/views/components/layouts/app/sidebar.blade.php
@@ -32,15 +32,21 @@
             </div>
 
             <flux:navlist variant="outline">
-                <x-menu menu-builder="sidebar" />
-                <x-menu menu-builder="media-management" />
-                <x-menu menu-builder="administration" />
+                @foreach (config('menu.globals', ['sidebar']) as $builder)
+                    <x-menu :menu-builder="$builder" />
+                @endforeach
             </flux:navlist>
+
+            {{-- Sections (Administration, Media, …) are chosen via a single switcher;
+                 the sidebar shows one section at a time. See config/menu.php. --}}
+            <x-section-switcher />
 
             <flux:spacer />
 
             <flux:navlist variant="outline">
-                <x-menu menu-builder="sidebar-footer" />
+                @foreach (config('menu.footer', ['sidebar-footer']) as $builder)
+                    <x-menu :menu-builder="$builder" />
+                @endforeach
             </flux:navlist>
 
             <!-- Desktop User Menu -->

--- a/stubs/resources/views/components/menu/section-items.blade.php
+++ b/stubs/resources/views/components/menu/section-items.blade.php
@@ -1,0 +1,42 @@
+{{-- Renders a section's menu items WITHOUT a group heading — the section
+     switcher dropdown already names the active section, so repeating it as a
+     heading would be redundant. Item markup mirrors components/menu/expanded.blade
+     (children → nested sub-group, form, link). Expects: $menuItems (collection). --}}
+@foreach ($menuItems as $menuItem)
+    @continue(! data_get($menuItem, 'visible', true))
+
+    @if (! empty(data_get($menuItem, 'children')))
+        <x-navlist-with-child :menu="$menuItem" />
+    @elseif (data_get($menuItem, 'type', 'link') === 'form')
+        @php $formMethod = strtoupper(data_get($menuItem, 'formAttributes.method', 'POST')); @endphp
+        <form method="{{ $formMethod === 'GET' ? 'GET' : 'POST' }}" action="{{ data_get($menuItem, 'url') }}"
+            @foreach (data_get($menuItem, 'formAttributes', []) as $attr => $value)
+                @if ($attr !== 'method') {{ $attr }}="{{ $value }}" @endif
+            @endforeach>
+            @if (! in_array($formMethod, ['GET', 'POST']))
+                @method($formMethod)
+            @endif
+            @csrf
+            <flux:navlist.item icon="{{ data_get($menuItem, 'icon', 'circle') }}" as="button" type="submit"
+                class="w-full cursor-pointer" :current="data_get($menuItem, 'active', false)"
+                title="{{ data_get($menuItem, 'label', 'Menu Item') }}">
+                <span class="block truncate">{{ data_get($menuItem, 'label', 'Menu Item') }}</span>
+            </flux:navlist.item>
+        </form>
+    @elseif (data_get($menuItem, 'target') === '_blank')
+        <flux:navlist.item icon="{{ data_get($menuItem, 'icon', 'circle') }}"
+            :href="data_get($menuItem, 'url')" :current="data_get($menuItem, 'active', false)"
+            target="_blank" rel="noopener noreferrer" title="{{ data_get($menuItem, 'label', 'Menu Item') }}">
+            <span class="flex w-full items-center justify-between gap-2 min-w-0">
+                <span class="min-w-0 truncate">{{ data_get($menuItem, 'label', 'Menu Item') }}</span>
+                <flux:icon.arrow-top-right-on-square class="size-3.5 shrink-0 opacity-60" />
+            </span>
+        </flux:navlist.item>
+    @else
+        <flux:navlist.item icon="{{ data_get($menuItem, 'icon', 'circle') }}"
+            :href="data_get($menuItem, 'url')" :current="data_get($menuItem, 'active', false)" wire:navigate
+            title="{{ data_get($menuItem, 'label', 'Menu Item') }}">
+            <span class="block truncate">{{ data_get($menuItem, 'label', 'Menu Item') }}</span>
+        </flux:navlist.item>
+    @endif
+@endforeach

--- a/stubs/resources/views/components/section-switcher.blade.php
+++ b/stubs/resources/views/components/section-switcher.blade.php
@@ -1,0 +1,60 @@
+{{-- Sidebar section switcher.
+
+     One dropdown names the active section (Administration, Media, …); the sidebar
+     then shows only that section's items. Picking a section navigates
+     (wire:navigate) to its landing page. The active section is derived from the
+     current route by App\Actions\Builder\Menu\SectionResolver (longest URL-prefix
+     match), so deep-links and item clicks always land on the right section with
+     no client-side state to keep in sync.
+
+     Sections come from config('menu.sections'); each reuses its menu builder for
+     data + authorization, so per-item permission gates and empty-section hiding
+     keep working untouched. When no section is authorized (e.g. a user with only
+     global items), the whole control renders nothing. --}}
+@php
+    $resolved = \App\Actions\Builder\Menu\SectionResolver::resolve();
+    $sections = $resolved['sections'];
+    $active = $resolved['active'];
+@endphp
+
+@if ($active)
+    {{-- Expanded sidebar: switcher control + the active section's items --}}
+    <div class="sidebar-expanded-only">
+        <flux:dropdown position="bottom" align="start" class="mt-2 w-full">
+            <flux:button variant="ghost" size="sm" icon="{{ $active['icon'] }}"
+                class="w-full justify-between text-left" data-tippy-content="{{ __('Switch section') }}">
+                <span class="min-w-0 flex-1 truncate">{{ $active['label'] }}</span>
+                <flux:icon.chevron-down class="size-4 shrink-0 text-zinc-400" />
+            </flux:button>
+
+            <flux:menu class="min-w-56">
+                @foreach ($sections as $section)
+                    <flux:menu.item icon="{{ $section['icon'] }}" :href="$section['landing']" wire:navigate
+                        @class(['font-semibold' => $section['key'] === $active['key']])>
+                        {{ $section['label'] }}
+                    </flux:menu.item>
+                @endforeach
+            </flux:menu>
+        </flux:dropdown>
+
+        <flux:navlist variant="outline" class="mt-2">
+            @include('components.menu.section-items', ['menuItems' => $active['items']])
+        </flux:navlist>
+    </div>
+
+    {{-- Collapsed rail: each section becomes a flyout icon (reuses the shared
+         collapsed template so items/children render exactly as elsewhere). --}}
+    <div class="sidebar-collapsed-only">
+        <flux:navlist variant="outline">
+            @foreach ($sections as $section)
+                @include('components.menu.collapsed', [
+                    'menu' => null,
+                    'menuItems' => $section['items'],
+                    'heading' => $section['label'],
+                    'headingIcon' => $section['icon'],
+                    'hasActiveItem' => $section['owns'],
+                ])
+            @endforeach
+        </flux:navlist>
+    </div>
+@endif

--- a/stubs/tests/Feature/SectionResolverTest.php
+++ b/stubs/tests/Feature/SectionResolverTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\Actions\Builder\Menu\SectionResolver;
+use App\Models\User;
+use Database\Seeders\AccessControlSeeder;
+use Illuminate\Http\Request;
+
+use function Pest\Laravel\actingAs;
+
+beforeEach(function () {
+    $this->seed(AccessControlSeeder::class);
+    $this->admin = User::factory()->create();
+    $this->admin->assignRole('superadmin');
+});
+
+test('resolve() returns the authorized sections with heading metadata', function () {
+    actingAs($this->admin);
+
+    $sections = collect(SectionResolver::resolve()['sections']);
+
+    expect($sections->pluck('key')->all())->toContain('administration', 'media-management')
+        ->and($sections->firstWhere('key', 'administration')['label'])->toBe('Administration')
+        ->and($sections->firstWhere('key', 'administration')['landing'])->toBe(route('admin.index'));
+});
+
+test('every section exposes a real (non-#) landing URL', function () {
+    actingAs($this->admin);
+
+    foreach (SectionResolver::resolve()['sections'] as $section) {
+        expect($section['landing'])->not->toBe('#');
+    }
+});
+
+test('the active section is the one owning the current URL by prefix', function () {
+    actingAs($this->admin);
+
+    // A sub-page under Administration that is not itself a menu leaf.
+    app()->instance('request', Request::create(route('admin.roles.index').'/42/edit'));
+
+    $active = SectionResolver::resolve()['active'];
+
+    expect($active['key'])->toBe('administration')
+        ->and($active['owns'])->toBeTrue();
+});
+
+test('with no section owning the URL, the first section is the fallback active', function () {
+    actingAs($this->admin);
+
+    app()->instance('request', Request::create('http://localhost/some/unmatched/path'));
+
+    $resolved = SectionResolver::resolve();
+
+    expect($resolved['active'])->not->toBeNull()
+        ->and($resolved['active']['key'])->toBe($resolved['sections'][0]['key']);
+});


### PR DESCRIPTION
Brings the section-switcher sidebar pattern into Kickoff so new and existing projects get a consistent way to structure the sidebar **and** breadcrumbs.

## What
Replaces the flat stacked menu groups with a **section switcher**: one dropdown names the active section, the sidebar shows only that section's items, and picking a section `wire:navigate`s to its landing page. Active section is derived from the current route by **longest URL-prefix** match (so sub-pages keep the right section).

`config/menu.php` is the **single source of truth** — an ordered list of builder keys:

```php
return [
    'globals'  => ['sidebar'],                             // pinned top
    'sections' => ['administration', 'media-management'],  // switcher
    'footer'   => ['sidebar-footer'],                      // pinned bottom
];
```

A section's **label / icon / landing** come from its builder heading (`getHeadingLabel/Icon/Url`) — no duplicated metadata. The **breadcrumb builder reads the same registry**, so navigation and breadcrumbs can never drift. Adding a section is a one-line config change.

## Files
| File | Type |
|---|---|
| `stubs/config/menu.php` | new — registry |
| `stubs/app/Actions/Builder/Menu/SectionResolver.php` | new — resolves sections, prefix active-detection, firstLeafUrl landing |
| `stubs/resources/views/components/section-switcher.blade.php` | new — dropdown + items + collapsed rail |
| `stubs/resources/views/components/menu/section-items.blade.php` | new — headingless items |
| `stubs/resources/views/components/layouts/app/sidebar.blade.php` | edit — globals → switcher → footer from config |
| `stubs/app/Actions/Builder/Breadcrumb.php` | edit — `SOURCES` → config-derived `sources()` |
| `stubs/docs/02-development/09-sidebar.md` | edit — rewritten (was stale) |
| `stubs/tests/Feature/SectionResolverTest.php` | new |

## Notes
- **Switcher is the only layout** — no flat mode / toggle, by design.
- **Installer/patch:** no change — `StartCommand` copies the whole `stubs/` tree; configs already ship from `stubs/config`.
- **Breadcrumb parity:** new `sources()` resolves to `[administration, media-management, sidebar-footer, sidebar]` — identical to the old hardcoded `SOURCES`, so `BreadcrumbBuilderTest` is unaffected.

## Verification
- `php -l` clean on all changed PHP; **Pint passed** on every new/changed file.
- Not runtime-tested here (Kickoff is a stub package with no bootable app); the resolver logic is a port of the switcher already running + tested in a downstream app. Runtime coverage lands when applied to a project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)